### PR TITLE
Update st_Step7_CNV_analysis.R

### DIFF
--- a/R/st_Step7_CNV_analysis.R
+++ b/R/st_Step7_CNV_analysis.R
@@ -69,9 +69,9 @@ st_CNV <- function(
                 save_path = save_path)
 
     pred.test <- data.frame(copykat.test$prediction)
-    rownames(pred.test) <- make.names(pred.test)
-    pred.test <- pred.test[make.names(colnames(st_obj)), 'copykat.pred']
-    st_obj <- AddMetaData(st_obj, pred.test, col.name = 'CNV_state')
+    st_obj@meta.data$cell.names <- row.names(st_obj@meta.data)
+    st_obj@meta.data$CNV_state <- pred.test$copykat.pred[match(st_obj@meta.data$cell.names, pred.test$cell.names)]#return x in y
+
     st_obj$CNV_state[st_obj$CNV_state == 'aneuploid'] <- 'Aneuploid'
     st_obj$CNV_state[st_obj$CNV_state == 'diploid'] <- 'Diploid'
     suppressMessages(suppressWarnings(


### PR DESCRIPTION
替换了原来的三行代码，因为测试中发现：
1. > rownames(pred.test) <- make.names(pred.test) Error in `.rowNamesDF<-`(x, value = value) : invalid 'row.names' length，这行代码好像没必要？
2. 另外，可以直接用barcode匹配，不用copykat结果中的行名（因为发现没预测出cnv的细胞行名不是barcode），用原来的代码加入st_obj@metadata后，not.defined的细胞在CNV.state列的值会变成NA
                    cell.names                         copykat.pred
X                  GCGCTGGCGGAAAGTC-1  not.defined
X.1                TACTCATTGACGCATC-1  not.defined
![image](https://github.com/user-attachments/assets/203f21b1-9d33-4ce2-ac11-6bb1c7dd9acc)
